### PR TITLE
`main` <-- `feat/add-outputs-in-workflow` Enhance GitHub Actions with tfvars output and update Ansible workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -112,7 +112,7 @@ jobs:
           echo "Waiting 60s for SSM agent..."
           sleep 60
 
-      - name: Run Ansible Inventory file
+      - name: Run Ansible Inventory and Playbook
         working-directory: Ansible
         # possible flags are --graph, --list and --host
         run: |

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           python yaml-to-json.py | tee terraform.tfvars.json
           mv terraform.tfvars.json ../IaC/
+          echo "tfvars=$(cat ../IaC/terraform.tfvars.json | jq -c .)" >> $GITHUB_OUTPUT
 
       - name: Connect to Cloud Provider
         uses: aws-actions/configure-aws-credentials@v5.0.0

--- a/Ansible/inventory_aws.aws_ec2.yml
+++ b/Ansible/inventory_aws.aws_ec2.yml
@@ -16,5 +16,9 @@ compose:
   ansible_host: instance_id
   ansible_python_interpreter: "'/usr/bin/python3'"
   ansible_aws_ssm_region: "'us-east-1'"
+  # TODO: Create the bucket name using Terraform
+  # Make an entry in the IaC/main.tf with S3 module
+  # Create a module in Terraform, to accept the list of bucket names from the parent module
+  # Create the bucket ( with default for quickspin-ansible-ssm-staging )
   ansible_aws_ssm_bucket_name: "'quickspin-ansible-ssm-staging'"
   quickspin_packages: tags.Packages | default('', true) | split(',') | reject('equalto', '') | list

--- a/quickspin-claude-context/ansible-learning-journey-README.md
+++ b/quickspin-claude-context/ansible-learning-journey-README.md
@@ -282,4 +282,38 @@ Every key defined in `compose` becomes a host variable available in playbooks �
 
 ---
 
+## 16. GitHub Actions — `GITHUB_OUTPUT` (Passing Data Between Steps/Jobs)
+
+### Between Steps
+
+```yaml
+- name: Set a value
+  id: my_step                    # ← required to reference later
+  run: echo "key=value" >> $GITHUB_OUTPUT
+
+- name: Use the value
+  run: echo "${{ steps.my_step.outputs.key }}"
+```
+
+### Between Jobs
+
+```yaml
+jobs:
+  job1:
+    outputs:
+      my_key: ${{ steps.my_step.outputs.my_key }}   # ← expose to other jobs
+    steps:
+      - id: my_step
+        run: echo "my_key=hello" >> $GITHUB_OUTPUT
+
+  job2:
+    needs: job1
+    steps:
+      - run: echo "${{ needs.job1.outputs.my_key }}"
+```
+
+**Pattern:** `steps.<id>.outputs.<key>` within a job, `needs.<job>.outputs.<key>` across jobs.
+
+---
+
 *New concepts will be added as we encounter them throughout the project.*


### PR DESCRIPTION
- Store terraform.tfvars.json content as GitHub Actions output variable for use in subsequent steps/jobs
- Add documentation for passing data between steps and jobs using GITHUB_OUTPUT in ansible-learning-journey-README.md
- Rename step in deployment workflow to "Run Ansible Inventory and Playbook"
- Add TODO comment in inventory file for creating S3 bucket via Terraform
- Document plan to create Terraform module for bucket management